### PR TITLE
Fixed bug when deleting a policy

### DIFF
--- a/azurerm/internal/services/devtestlabs/dev_test_policy_resource.go
+++ b/azurerm/internal/services/devtestlabs/dev_test_policy_resource.go
@@ -214,7 +214,7 @@ func resourceArmDevTestPolicyDelete(d *schema.ResourceData, meta interface{}) er
 	policySetName := id.Path["policysets"]
 	name := id.Path["policies"]
 
-	read, err := client.Get(ctx, resourceGroup, policySetName, labName, name, "")
+	read, err := client.Get(ctx, resourceGroup, labName, policySetName, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
 			// deleted outside of TF


### PR DESCRIPTION
Deleting a policy returns success, without deleting the resource. Reading the resource was always returning null, since the labName and policySetName is mixed.

